### PR TITLE
various fixes

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -148,7 +148,7 @@ including:
 (i)~types of supported objective functions,
 (ii)~selection of available optimizers,
 (iii)~support for custom behavior via callback functions,
-(iv)~support for various underlying element and matrix types used by objective functions.
+(iv)~support for various underlying element and matrix types used by objective functions,
 and
 (v)~extensibility, to facilitate adding more optimizers.
 
@@ -584,8 +584,8 @@ The source code and documentation are freely available at \mbox{\url{https://ens
 
 Further details, such as internal use of template metaprogramming
 for automatic generation of efficient code, automatic function inference,
-clean error reporting, and various approaches for obtaining efficiency
-are discussed in the accompanying technical report~\citep{ensmallen2020}.
+clean error reporting, and various approaches for obtaining efficiency,
+are all discussed in the accompanying technical report~\citep{ensmallen2020}.
 
 
 % Acknowledgements should go at the end, before appendices and references


### PR DESCRIPTION
- intro: fix errant full stop by changing it to an oxford comma
- conclusion: add oxford comma for better readability; use "are all discussed" phrasing for emphasis